### PR TITLE
feat(rclone): Implement support for empty salts

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -9,3 +9,4 @@ export const fileHeaderSize = fileMagicSize + fileNonceSize;
 export const blockHeaderSize = 16; // crypto_secretbox_BOXZEROBYTES
 export const blockDataSize = 64 * 1024;
 export const blockSize = blockHeaderSize + blockDataSize;
+export const defaultSalt = [0xa8, 0x0d, 0xf4, 0x3a, 0x8f, 0xbd, 0x03, 0x08, 0xa7, 0xca, 0xb8, 0x3e, 0x58, 0x1f, 0x86, 0xb1];

--- a/src/rclone.js
+++ b/src/rclone.js
@@ -9,7 +9,8 @@ import {
   fileHeaderSize,
   blockHeaderSize,
   blockDataSize,
-  blockSize
+  blockSize,
+  defaultSalt
 } from './constants';
 
 function Rclone({ password, salt } = {}) {
@@ -50,7 +51,9 @@ export { Rclone };
 // pass and salt are still encrypted with the rclone config encryption
 function generateKeys(encPass, encSalt, callback) {
   const password = reveal(encPass);
-  const salt = reveal(encSalt);
+  const decryptedSalt = reveal(encSalt);
+  const salt = decryptedSalt.length ? decryptedSalt : defaultSalt;
+  
   if (password.length === 0) {
     // Empty key for testing
     callback(

--- a/src/rclone.test.js
+++ b/src/rclone.test.js
@@ -1,4 +1,6 @@
 import { Rclone } from './rclone';
+import {defaultSalt} from './constants';
+import PathCipher from './ciphers/PathCipher';
 
 test('both password and salt must be passed', done => {
   Rclone({
@@ -13,6 +15,25 @@ test('derive keys from password', done => {
   })
     .then(rclone => {
       expect(rclone).toMatchSnapshot('empty key rclone');
+      done();
+    })
+    .catch(err => done.fail(err));
+});
+
+test('use default salt when empty', done => {
+  // Generated encrypted string with the use of rclone and empty salt
+  const rcloneEncryptedFileName = 'ecrk8fu3e0pk86td3r634nan08';
+  const rcloneDecryptedFileName = 'encrypted_file'
+
+   Rclone({
+    password: 'UmyLSdRHfew6aual28-ggx78qHqSfQ',
+    salt: ''
+  })
+    .then(rclone => {
+      const pathCipher = PathCipher(rclone);
+      const decryptedString = pathCipher.decrypt(rcloneEncryptedFileName);
+
+      expect(decryptedString).toEqual(rcloneDecryptedFileName);
       done();
     })
     .catch(err => done.fail(err));


### PR DESCRIPTION
If an empty string is used as a salt then it should be replaced with a default one as also done by rclone:
https://github.com/rclone/rclone/blob/b9bd15a8c980c36f15dd9b90bc0c422e4020baec/backend/crypt/cipher.go#L175

The default salt that must be used can be found here:
https://github.com/rclone/rclone/blob/b9bd15a8c980c36f15dd9b90bc0c422e4020baec/backend/crypt/cipher.go#L54