### PR TITLE
Support base64 path encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ import { Rclone } from 'rclone';
 // Create Rclone instance 
 Rclone({
     password: 'UmyLSdRHfew6aual28-ggx78qHqSfQ',
-    salt: 'Cj3gLa5PVwc2aot0QpKiOZ3YEzs3Sw'
+    salt: 'Cj3gLa5PVwc2aot0QpKiOZ3YEzs3Sw',
+    encoding: 'base32' // Path encoding type, default is base32. base32 and base64 only.
 })
 .then(rclone => { 
    

--- a/src/ciphers/PathCipher.test.js
+++ b/src/ciphers/PathCipher.test.js
@@ -6,7 +6,7 @@ test('both nameKey and nameTweak are need', () => {
   }).toThrowErrorMatchingSnapshot();
 });
 
-test('shoud encrypt/decrypt file name', () => {
+test('shoud encrypt/decrypt file name [base32]', () => {
   const cases = [
     ['es785ret6k0hje8fkrqmu9fdus', 'Hallo World'],
     ['p0e52nreeaj0a5ea7s64m4j72s', '1'],
@@ -21,6 +21,31 @@ test('shoud encrypt/decrypt file name', () => {
     nameKey: new Uint8Array(32),
     nameTweak: new Uint8Array(16)
   });
+
+  cases.forEach(item => {
+    expect(cipher.decrypt(item[0])).toEqual(item[1]);
+  });
+
+  cases.forEach(item => {
+    expect(cipher.encrypt(item[1])).toEqual(item[0]);
+  });
+});
+
+test('shoud encrypt/decrypt file name [base64]', () => {
+  const cases = [
+    ['dw6C7d01ARm5D6b1byXt9w', 'Hallo World'],
+    ['yBxRX25ypgUVyj8MSxJnFw', '1'],
+    ['yBxRX25ypgUVyj8MSxJnFw/qQUDHOGN_jVdLIMQzYrhvA', '1/12'],
+    [
+      'yBxRX25ypgUVyj8MSxJnFw/qQUDHOGN_jVdLIMQzYrhvA/1CxFf2Mti1xIPYlGruDh-A',
+      '1/12/123'
+    ]
+  ];
+
+  const cipher = PathCipher({
+    nameKey: new Uint8Array(32),
+    nameTweak: new Uint8Array(16)
+  }, 'base64');
 
   cases.forEach(item => {
     expect(cipher.decrypt(item[0])).toEqual(item[1]);

--- a/src/ciphers/path-encoding.js
+++ b/src/ciphers/path-encoding.js
@@ -1,0 +1,21 @@
+import { default as decodeBase32 } from 'base32-decode';
+import { default as encodeBase32 } from 'base32-encode';
+import { decodeBase64, encodeBase64, toSafeForFileName, toNormal } from '../utils/base64';
+
+const encodings = {
+  base32: {
+    encode: (data) => encodeBase32(data, 'RFC4648-HEX').replace(/=+$/, '').toLowerCase(),
+    decode: (data) => decodeBase32(data.toUpperCase(), 'RFC4648-HEX')
+  },
+  base64: {
+    encode: (data) => toSafeForFileName(encodeBase64(data)),
+    decode: (data) => decodeBase64(toNormal(data))
+  }
+}
+
+export default (encodingType) => {
+  const e = encodings[encodingType]
+
+  if (!e) throw new Error('Unsupported path encoding types');
+  return e
+}

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,6 @@ export function Rclone(opts) {
   return RcloneInternal(opts).then(keys => ({
     getKeys: () => keys,
     File: FileCipher(keys),
-    Path: PathCipher(keys)
+    Path: PathCipher(keys, opts.encoding)
   }));
 }

--- a/src/rclone.test.js
+++ b/src/rclone.test.js
@@ -22,7 +22,8 @@ test('derive keys from password', done => {
 
 test('use default salt when empty', done => {
   // Generated encrypted string with the use of rclone and empty salt
-  const rcloneEncryptedFileName = 'ecrk8fu3e0pk86td3r634nan08';
+  const rcloneEncryptedFileNameBase32 = 'ecrk8fu3e0pk86td3r634nan08';
+  const rcloneEncryptedFileNameBase64 = 'czdEP8NwM0QbrR7MMl1XAg';
   const rcloneDecryptedFileName = 'encrypted_file'
 
    Rclone({
@@ -30,10 +31,14 @@ test('use default salt when empty', done => {
     salt: ''
   })
     .then(rclone => {
-      const pathCipher = PathCipher(rclone);
-      const decryptedString = pathCipher.decrypt(rcloneEncryptedFileName);
-
+      let pathCipher = PathCipher(rclone);
+      let decryptedString = pathCipher.decrypt(rcloneEncryptedFileNameBase32);
       expect(decryptedString).toEqual(rcloneDecryptedFileName);
+
+      pathCipher = PathCipher(rclone, 'base64');
+      decryptedString = pathCipher.decrypt(rcloneEncryptedFileNameBase64);
+      expect(decryptedString).toEqual(rcloneDecryptedFileName);
+
       done();
     })
     .catch(err => done.fail(err));

--- a/src/reveal.js
+++ b/src/reveal.js
@@ -1,4 +1,5 @@
 import AES from 'aes-js';
+import { decodeBase64 } from './utils/base64'
 const { ctr } = AES.ModeOfOperation;
 
 // prettier-ignore
@@ -21,7 +22,7 @@ function reveal(cipherText) {
   const blockCipher = createCipher();
 
   cipherText = cipherText.replace(/-/g, '+').replace(/_/g, '/');
-  const bytes = base64(cipherText);
+  const bytes = decodeBase64(cipherText);
 
   const iv = bytes.subarray(0, 16);
   const buf = bytes.subarray(16);
@@ -35,25 +36,4 @@ function reveal(cipherText) {
   return ctrCipher.decrypt(buf);
 }
 
-export { reveal };
-
-function base64(s) {
-  if (s.length % 4 != 0) {
-    s += '===='.substr(0, 4 - s.length % 4);
-  }
-  return new Uint8Array(
-    atob2(s)
-      .split('')
-      .map(charCodeAt)
-  );
-}
-
-function atob2(data) {
-  return typeof atob === 'function'
-    ? atob(data)
-    : Buffer.from(data, 'base64').toString('binary');
-}
-
-function charCodeAt(c) {
-  return c.charCodeAt(0);
-}
+export { reveal }

--- a/src/utils/base64.js
+++ b/src/utils/base64.js
@@ -1,0 +1,39 @@
+export function decodeBase64(s) {
+    if (s.length % 4 != 0) {
+        s += '===='.substr(0, 4 - s.length % 4);
+    }
+    return new Uint8Array(
+        atob2(s)
+            .split('')
+            .map(charCodeAt)
+    );
+}
+
+export function encodeBase64(data) {
+    return typeof atob === 'function'
+        ? btoa(String.fromCharCode.apply(null, data))
+        : Buffer.from(data).toString('base64');
+}
+
+export function toSafeForFileName(str) {
+    return str
+        .replace(/=+$/, '')
+        .replace(/\//g, '_')
+        .replace(/\+/g, '-')
+}
+
+export function toNormal(str) {
+    return str
+        .replace(/_/g, '/')
+        .replace(/-/g, '+')
+}
+
+function atob2(data) {
+    return typeof atob === 'function'
+        ? atob(data)
+        : Buffer.from(data, 'base64').toString('binary');
+}
+
+function charCodeAt(c) {
+    return c.charCodeAt(0);
+}


### PR DESCRIPTION
Supports base64 path encoding to reduce filename lengths

https://rclone.org/crypt/#file-name-encryption-modes
> An experimental advanced option filename_encoding is now provided to address this problem to a certain degree. For cloud storage systems with case sensitive file names (e.g. Google Drive), base64 can be used to reduce file name length. For cloud storage systems using UTF-16 to store file names internally (e.g. OneDrive, Dropbox, Box), base32768 can be used to drastically reduce file name length.